### PR TITLE
add endpoint for metadata only

### DIFF
--- a/bundestag_api/bta_wrapper.py
+++ b/bundestag_api/bta_wrapper.py
@@ -131,13 +131,13 @@ class btaConnection:
                 be supplied as a list but they will be joined via AND. An OR-
                 search is not possible
             sachgebiet: str/list, optional
-                Political field that is connected to the entities. Multiple 
+                Political field that is connected to the entities. Multiple
                 strings can be supplied as a list but they will be joined via
                 AND. An OR-search is not possible
             document_type: str, optional
                 The type of document to be returned.
             title: str/list, optional
-                Keyword that can be found in the title of documents. Multiple 
+                Keyword that can be found in the title of documents. Multiple
                 strings can be supplied as a list and will be joined via
                 an OR-search.
         """
@@ -380,15 +380,15 @@ class btaConnection:
         descriptor: str/list, optional
             Keyword that is connected to the entities. Multiple strings can
             be supplied as a list but they will be joined via AND. An OR-
-            search is not possible         
+            search is not possible
         sachgebiet: str/list, optional
-            Political field that is connected to the entities. Multiple 
+            Political field that is connected to the entities. Multiple
             strings can be supplied as a list but they will be joined via
             AND. An OR-search is not possible
         document_type: str, optional
             The type of document to be returned.
         title: str/list, optional
-            Keyword that can be found in the title of documents. Multiple 
+            Keyword that can be found in the title of documents. Multiple
             strings can be supplied as a list and will be joined via
             an OR-search.
 
@@ -487,7 +487,7 @@ class btaConnection:
         document_type: str, optional
             The type of document to be returned.
         title: str/list, optional
-            Keyword that can be found in the title of documents. Multiple 
+            Keyword that can be found in the title of documents. Multiple
             strings can be supplied as a list and will be joined via
             an OR-search.
 
@@ -593,7 +593,7 @@ class btaConnection:
         document_type: str, optional
             The type of document to be returned.
         title: str/list, optional
-            Keyword that can be found in the title of documents. Multiple 
+            Keyword that can be found in the title of documents. Multiple
             strings can be supplied as a list and will be joined via
             an OR-search.
 
@@ -638,7 +638,7 @@ class btaConnection:
             yet. Other option is "object" which will return results as class
             objects
         fulltext: boolean
-            Whether the fulltext (if available) should be requested or not. Default is False    
+            Whether the fulltext (if available) should be requested or not. Default is False
 
         Returns
         -------
@@ -722,10 +722,10 @@ class btaConnection:
 
 
     def search_plenaryprotocol_meta(self,
-                               rformat="json",
+                               return_format="json",
                                num=100,
-                               datestart=None,
-                               dateend=None,
+                               date_start=None,
+                               date_end=None,
                                institution=None):
         """
         Searches plenary protocols specified by the parameters, metadata.
@@ -754,9 +754,9 @@ class btaConnection:
         """
 
         data = self.query(resource="plenarprotokoll",
-                          rformat=rformat,
-                          datestart=datestart,
-                          dateend=dateend,
+                          return_format=return_format,
+                          date_start=date_start,
+                          date_end=date_end,
                           institution=institution,
                           num=num,)
 
@@ -923,7 +923,7 @@ class btaConnection:
         descriptor: str/list, optional
             Keyword that is connected to the entities. Multiple strings can
             be supplied as a list but they will be joined via AND. An OR-
-            search is not possible         
+            search is not possible
 
         Returns
         -------
@@ -1002,7 +1002,7 @@ class btaConnection:
                            "search_plenaryprotocol", "get_document",
                            "search_document", "get_procedureposition",
                            "search_procedureposition", "get_procedure",
-                           "search_procedure", "query"] 
+                           "search_procedure", "query"]
         """
         return list_of_methods
 

--- a/bundestag_api/bta_wrapper.py
+++ b/bundestag_api/bta_wrapper.py
@@ -719,6 +719,77 @@ class btaConnection:
                           return_format=return_format)
         return data
 
+
+
+    def search_plenaryprotocol_meta(self,
+                               rformat="json",
+                               num=100,
+                               datestart=None,
+                               dateend=None,
+                               institution=None):
+        """
+        Searches plenary protocols specified by the parameters, metadata.
+
+        Parameters
+        ----------
+        rformat: str, optional
+            Return format of the data. Defaults to json. XML not implemented
+            yet. Other option is "object" which will return results as class
+            objects
+        num: int, optional
+            Number of maximal results to be returned. Defaults to 100
+        datestart: str, optional
+            Date after which entities should be retrieved. Format
+            is "YYYY-MM-DD"
+        dateend: str, optional
+            Date before which entities should be retrieved. Format
+            is "YYYY-MM-DD"
+        institution: str, optional
+            Filter results by institution BT, BR, BV or EK
+
+        Returns
+        -------
+        data: list
+            a list of dictionaries or class objects of plenary protocols
+        """
+
+        data = self.query(resource="plenarprotokoll",
+                          rformat=rformat,
+                          datestart=datestart,
+                          dateend=dateend,
+                          institution=institution,
+                          num=num,)
+
+        return data
+
+    def get_plenaryprotocol_meta(self,
+                                 btid,
+                                 rformat="json"):
+        """
+        Retrieves plenary protocols specified by IDs, only metadata.
+
+        Parameters
+        ----------
+        btid: int/list
+            ID of a plenary protocol entity. Can be a list to retrieve more than
+            one entity
+        rformat: str, optional
+            Return format of the data. Defaults to json. XML not implemented
+            yet. Other option is "object" which will return results as class
+            objects
+
+        Returns
+        -------
+        data: list
+            a list of dictionaries or class objects of plenary protocols
+        """
+
+        data = self.query(resource="plenarprotokoll",
+                          fid=btid,
+                          rformat=rformat)
+
+        return data
+
     def search_plenaryprotocol(self,
                                return_format="json",
                                num=100,


### PR DESCRIPTION

Relates to #4 

It contains the most straightforward implementation adding additional methods `search_plenaryprotocol_meta` and `get_plenaryprotocol_meta`. This however needn't be the best solution.

It generates a somewhat unfortunate mismatch when compared to the [swagger UI](https://search.dip.bundestag.de/api/v1/swagger-ui/) endpoint namings.


